### PR TITLE
Fix infinite loop in Firefly on empty events

### DIFF
--- a/nebulacore/base_objects.py
+++ b/nebulacore/base_objects.py
@@ -204,7 +204,9 @@ class ItemMixIn(object):
     def __getitem__(self, key):
         key = key.lower().strip()
         if not key in self.meta:
-            if key not in ["id_asset"] and self.asset:
+            if key == "id_asset":
+                return 0
+            elif self.asset:
                 return self.asset[key]
             else:
                 return self.meta_types[key].default


### PR DESCRIPTION
Now that meta types are per-folder, to look up a default for id_asset
requires the item's meta types which requires the asset's meta types
which requires the id_asset which... causes an infinite loop. Oops.

Firefly apparently uses an Item without an id_asset to represent "empty event"
and triggers this. The code already avoided a direct reference to self.asset, but now self.meta_types indirectly references self.asset.